### PR TITLE
修复windows下无法关闭nginx的bug

### DIFF
--- a/src/main/java/com/cym/controller/adminPage/ConfController.java
+++ b/src/main/java/com/cym/controller/adminPage/ConfController.java
@@ -376,7 +376,7 @@ public class ConfController extends BaseController {
 		try {
 			String cmd;
 			if (SystemTool.isWindows()) {
-				cmd = "taskkill /im /f nginx.exe ";
+				cmd = "taskkill /im nginx.exe /f";
 			} else {
 				cmd = "pkill nginx";
 			}


### PR DESCRIPTION
taskkill的用法应为 taskkill /im <进程名> /f ，目前版本会导致参数错误

详情请见https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/taskkill