### PR TITLE
http端口监听支持范围，default值改成default_server

### DIFF
--- a/src/main/java/com/cym/service/ConfService.java
+++ b/src/main/java/com/cym/service/ConfService.java
@@ -414,14 +414,11 @@ public class ConfService {
 		return ngxBlockServer;
 	}
 
-	public static Boolean processListenPort(Server server, NgxBlock ngxBlockServer, Boolean isIpv6) {
-		if (isIpv6 && server.getIpv6() != 1){
-			return false;
-		}
+	public static List<Integer> processPort(String listenString){
 		List<Integer> numbers = new ArrayList<>();
 
 		// 使用逗号分割字符串
-		String[] partsByComma = server.getListen().split(",");
+		String[] partsByComma = listenString.split(",");
 
 		for (String part : partsByComma) {
 			String[] range = part.split("-");
@@ -445,14 +442,19 @@ public class ConfService {
 				numbers.add(num);
 			}
 		}
+		return numbers;
+	}
 
-		String listenKey = "listen ";
-		if (isIpv6){
-			listenKey = "listen [::]:";
+	public static Boolean processListenPort(Server server, NgxBlock ngxBlockServer, Boolean isIpv6) {
+		if (isIpv6 && server.getIpv6() != 1){
+			return false;
 		}
+		List<Integer> ports = processPort(server.getListen());
+
+		String listenKey = isIpv6 ? "listen [::]:" : "listen ";
 
 		String value = "";
-		for (Integer port : numbers) {
+		for (Integer port : ports) {
 			NgxParam ngxParam = new NgxParam();
 			value = listenKey + port;
 			if (server.getDef() == 1) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bbafc4bc-8623-4865-9e3f-10694e0071d7)
![image](https://github.com/user-attachments/assets/f04559ee-bc51-4bc9-b1d7-e4d312944dcc)
监听范围，相同配置避免重复配置端口（比如所有端口default服务都被拦截）