### PR TITLE
add CF_Token support

### DIFF
--- a/src/main/java/com/cym/controller/adminPage/CertController.java
+++ b/src/main/java/com/cym/controller/adminPage/CertController.java
@@ -321,7 +321,12 @@ public class CertController extends BaseController {
 			}
 			if (cert.getDnsType().equals("cf")) {
 				list.add("CF_Email=" + cert.getCfEmail());
-				list.add("CF_Key=" + cert.getCfKey());
+				if (cert.getCfToken() != null && !cert.getCfToken().isEmpty()) {
+					list.add("CF_Token=" + cert.getCfToken());
+				}
+				if (cert.getCfKey() != null && !cert.getCfKey().isEmpty()) {
+					list.add("CF_Key=" + cert.getCfKey());
+				}
 			}
 			if (cert.getDnsType().equals("gd")) {
 				list.add("GD_Key=" + cert.getGdKey());

--- a/src/main/java/com/cym/model/Cert.java
+++ b/src/main/java/com/cym/model/Cert.java
@@ -82,9 +82,13 @@ public class Cert extends BaseModel {
 	 */
 	String cfEmail;
 	/**
-	 * cfKey(Cloudflare需要的参数)
+	 * cfKey(Cloudflare需要的参数, 兼容老用户)
 	 */
 	String cfKey;
+	/**
+	 * cfToken(Cloudflare需要的参数, 推荐)
+	 */
+	String cfToken;
 
 	/**
 	 * gdKey(Godaddy需要的参数)
@@ -224,6 +228,14 @@ public class Cert extends BaseModel {
 
 	public void setCfKey(String cfKey) {
 		this.cfKey = cfKey;
+	}
+
+	public String getCfToken() {
+		return cfToken;
+	}
+
+	public void setCfToken(String cfToken) {
+		this.cfToken = cfToken;
 	}
 
 	public Integer getType() {

--- a/src/main/resources/WEB-INF/view/adminPage/cert/index.html
+++ b/src/main/resources/WEB-INF/view/adminPage/cert/index.html
@@ -302,6 +302,13 @@
 								<input type="text" name="cfKey" id="cfKey" class="layui-input">
 							</div>
 						</div>
+
+						<div class="layui-form-item">
+							<label class="layui-form-label">CF_Token</label>
+							<div class="layui-input-block">
+								<input type="text" name="cfToken" id="cfToken" class="layui-input">
+							</div>
+						</div>
 					</div>
 
 					<div id="gd">

--- a/src/main/resources/static/doc/CertApiController.html
+++ b/src/main/resources/static/doc/CertApiController.html
@@ -443,6 +443,7 @@
         "aliSecret": "",
         "cfEmail": "",
         "cfKey": "",
+        "cfToken": "",
         "gdKey": "",
         "gdSecret": "",
         "hwUsername": "",
@@ -626,7 +627,15 @@
                     <tr>
                         <td class="tableblock halign-left valign-top"><p class="tableblock">cfKey</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
-                        <td class="tableblock halign-left valign-top"><p class="tableblock">cfKey(Cloudflare需要的参数)</p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">cfKey(Cloudflare需要的参数, 兼容老用户)</p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+                    </tr>
+
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">cfToken</p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">cfToken(Cloudflare需要的参数, 推荐)</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
                         <td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
                     </tr>
@@ -699,7 +708,7 @@
                 <div class="paragraph"><p><strong>Request-example:</strong></p></div>
                 <div class="listingblock">
                     <div class="content">
-                        <pre><code class="bash">curl -X GET -i /api/cert/addOver?type=0&makeTime=0&endTime=0&autoRenew=0&gdSecret=&cfEmail=&tencentSecretId=&tencentSecretKey=&ipv64Token=&gdKey=&dpId=&dpKey=&dnsType=&aliSecret=&awsAccessKeyId=&key=&hwPassword=&hwUsername=&awsSecretAccessKey=&aliKey=&encryption=&domain=&hwDomainName=&pem=&cfKey=&id=</code></pre>
+                        <pre><code class="bash">curl -X GET -i /api/cert/addOver?type=0&makeTime=0&endTime=0&autoRenew=0&gdSecret=&cfEmail=&tencentSecretId=&tencentSecretKey=&ipv64Token=&gdKey=&dpId=&dpKey=&dnsType=&aliSecret=&awsAccessKeyId=&key=&hwPassword=&hwUsername=&awsSecretAccessKey=&aliKey=&encryption=&domain=&hwDomainName=&pem=&cfToken=&id=</code></pre>
                     </div>
                 </div>
                 <div class="paragraph"><p><strong>Response-fields:</strong></p></div>

--- a/src/main/resources/static/js/adminPage/cert/index.js
+++ b/src/main/resources/static/js/adminPage/cert/index.js
@@ -144,6 +144,7 @@ function add() {
 	$("#awsSecretAccessKey").val("");
 	$("#cfEmail").val("");
 	$("#cfKey").val("");
+	$("#cfToken").val("");
 	$("#gdKey").val("");
 	$("#gdSecret").val("");
 	$("#ipv64Token").val("");
@@ -205,6 +206,7 @@ function edit(id, clone) {
 				$("#awsSecretAccessKey").val(cert.awsSecretAccessKey);
 				$("#cfEmail").val(cert.cfEmail);
 				$("#cfKey").val(cert.cfKey);
+				$("#cfToken").val(cert.cfToken);
 
 				$("#gdKey").val(cert.gdKey);
 				$("#gdSecret").val(cert.gdSecret);
@@ -303,7 +305,7 @@ function addOver() {
 			}
 		}
 		if ($("#dnsType").val() == 'cf') {
-			if ($("#cfEmail").val() == '' || $("#cfKey").val() == '') {
+			if ($("#cfEmail").val() == '' || ($("#cfKey").val() == '' && $("#cfToken").val() == '')) {
 				layer.msg(commonStr.IncompleteEntry);
 				return;
 			}


### PR DESCRIPTION
支持cloudflare在dns api证书申请模式下，使用CF_Token变量而非CF_Key（全局KEY）申请