### PR TITLE
remove ngx_http_lua_upstream_module.so as dl error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22
+FROM alpine:3.21
 ENV LANG=zh_CN.UTF-8 \
     TZ=Asia/Shanghai \
     PS1="\u@\h:\w \$ "
@@ -13,8 +13,6 @@ RUN    apk add --update --no-cache \
 	   nginx-mod-http-headers-more \
 	   nginx-mod-http-js \
 	   nginx-mod-http-keyval \
-	   nginx-mod-http-lua \
-	   nginx-mod-http-lua-upstream \
 	   nginx-mod-http-brotli \
 	   nginx-mod-rtmp \
 	   nginx-mod-mail \

--- a/local_build.sh
+++ b/local_build.sh
@@ -1,0 +1,6 @@
+docker buildx build --load -t nginxwebui \
+    --cache-from "type=local,src=/tmp/.buildx-cache" \
+    --cache-to "type=local,dest=/tmp/.buildx-cache" \
+    --platform "linux/amd64" . 
+
+


### PR DESCRIPTION
nginx: [emerg] dlopen() "/var/lib/nginx/modules/ngx_http_lua_upstream_module.so" failed (Error relocating /var/lib/nginx/modules/ngx_http_lua_upstream_module.so: lua_concat: symbol not found) in /etc/nginx/modules/20_http_lua_upstream.conf:1