### PR TITLE
fix(docker): 升级 nginx 至 1.30.1 以修复安全漏洞 并添加构建工作流

### DIFF
--- a/.github/workflows/build_jar.yml
+++ b/.github/workflows/build_jar.yml
@@ -1,0 +1,48 @@
+name: Build JAR
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - "src/**"
+      - "pom.xml"
+      - ".github/workflows/build-jar.yml"
+  pull_request:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-jar:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "8"
+          cache: maven
+
+      - name: Build with Maven
+        run: mvn clean package -DskipTests
+
+      - name: List target files
+        run: ls -lah target
+
+      - name: Upload JAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nginxWebUI-jar
+          path: target/nginxWebUI-*.jar
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,86 @@
+name: Build Docker Image
+
+on:
+  workflow_run:
+    workflows:
+      - Build JAR
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  actions: read
+
+jobs:
+  build-docker:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Prepare image name
+        run: |
+          IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY}"
+          IMAGE_NAME_LOWER=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE_NAME=$IMAGE_NAME_LOWER" >> "$GITHUB_ENV"
+
+      - name: Download JAR artifact from Build JAR workflow
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: nginxWebUI-jar
+          path: target
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build JAR when manually triggered
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "8"
+          cache: maven
+
+      - name: Maven build when manually triggered
+        if: github.event_name == 'workflow_dispatch'
+        run: mvn clean package -DskipTests
+
+      - name: List target files
+        run: ls -lah target
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=nginx-1.30.1
+            type=raw,value=latest
+            type=sha,prefix=sha-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositor
     nginx-mod-http-upload=1.30.1-r0 \
     nginx-mod-http-upload-progress=1.30.1-r0 \
     nginx-mod-http-upstream-fair=1.30.1-r0 \
-    nginx-mod-http-upstream-jdomain=1.30.1-r0 \
     nginx-mod-http-echo=1.30.1-r0 \
     nginx-mod-http-cache-purge=1.30.1-r0 \
     nginx-mod-dynamic-upstream=1.30.1-r0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,51 +1,61 @@
 FROM alpine:3.22
+
 ENV LANG=zh_CN.UTF-8 \
     TZ=Asia/Shanghai \
     PS1="\u@\h:\w \$ "
-# RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
-RUN    apk add --update --no-cache \
-       nginx \
-	   nginx-mod-stream \
-	   nginx-mod-stream-geoip \
-	   nginx-mod-stream-geoip2 \
-	   nginx-mod-stream-js \
-	   nginx-mod-stream-keyval \
-	   nginx-mod-http-headers-more \
-	   nginx-mod-http-js \
-	   nginx-mod-http-keyval \
-	   nginx-mod-http-lua \
-	   nginx-mod-http-brotli \
-	   nginx-mod-rtmp \
-	   nginx-mod-mail \
-	   nginx-mod-http-geoip \
-	   nginx-mod-http-geoip2 \
-	   nginx-mod-http-zip \
-	   nginx-mod-http-zstd \
-	   nginx-mod-http-perl \
-	   nginx-mod-http-upload \
-	   nginx-mod-http-upload-progress \
-	   nginx-mod-http-upstream-fair \
-	   nginx-mod-http-upstream-jdomain \
-	   nginx-mod-http-echo \
-	   nginx-mod-http-cache-purge \
-	   nginx-mod-dynamic-upstream \
-	   nginx-mod-dynamic-healthcheck \
-       openjdk8-jre \
-       net-tools \
-       curl \
-       wget \
-       ttf-dejavu \
-       fontconfig \
-       tzdata \
-       logrotate \
-       tini \
-       acme.sh \
+
+# 只给 nginx 相关包使用 edge/main，避免整个系统无意切到 edge
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
+    && apk add --update --no-cache \
+    nginx=1.30.1-r0 \
+    nginx-mod-stream=1.30.1-r0 \
+    nginx-mod-stream-geoip=1.30.1-r0 \
+    nginx-mod-stream-geoip2=1.30.1-r0 \
+    nginx-mod-stream-js=1.30.1-r0 \
+    nginx-mod-stream-keyval=1.30.1-r0 \
+    nginx-mod-http-headers-more=1.30.1-r0 \
+    nginx-mod-http-js=1.30.1-r0 \
+    nginx-mod-http-keyval=1.30.1-r0 \
+    nginx-mod-http-lua=1.30.1-r0 \
+    nginx-mod-http-brotli=1.30.1-r0 \
+    nginx-mod-rtmp=1.30.1-r0 \
+    nginx-mod-mail=1.30.1-r0 \
+    nginx-mod-http-geoip=1.30.1-r0 \
+    nginx-mod-http-geoip2=1.30.1-r0 \
+    nginx-mod-http-zip=1.30.1-r0 \
+    nginx-mod-http-zstd=1.30.1-r0 \
+    nginx-mod-http-perl=1.30.1-r0 \
+    nginx-mod-http-upload=1.30.1-r0 \
+    nginx-mod-http-upload-progress=1.30.1-r0 \
+    nginx-mod-http-upstream-fair=1.30.1-r0 \
+    nginx-mod-http-upstream-jdomain=1.30.1-r0 \
+    nginx-mod-http-echo=1.30.1-r0 \
+    nginx-mod-http-cache-purge=1.30.1-r0 \
+    nginx-mod-dynamic-upstream=1.30.1-r0 \
+    nginx-mod-dynamic-healthcheck=1.30.1-r0 \
+    openjdk8-jre \
+    net-tools \
+    curl \
+    wget \
+    ttf-dejavu \
+    fontconfig \
+    tzdata \
+    logrotate \
+    tini \
+    acme.sh \
     && fc-cache -f -v \
     && ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo "${TZ}" > /etc/timezone \
+    && nginx -v \
+    && nginx -V \
     && rm -rf /var/cache/apk/* /tmp/*
+
 COPY target/nginxWebUI-*.jar /home/nginxWebUI.jar
+
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
 RUN ["chmod", "+x", "/usr/local/bin/entrypoint.sh"]
+
 VOLUME ["/home/nginxWebUI"]
+
 ENTRYPOINT ["tini", "entrypoint.sh"]


### PR DESCRIPTION
## 概要

本 PR 将 Docker 镜像中的 nginx 升级到 Alpine edge/main 中的 `1.30.1-r0`，并新增 GitHub Actions 工作流，用于自动编译 JAR 和构建 Docker 镜像。

此次升级主要用于修复 nginx `1.30.1` 之前版本中存在的高危安全漏洞，同时改善项目的自动化构建流程。
Related to #209 

## 主要修改

- 新增 JAR 编译工作流
  - 使用 Maven 编译项目
  - 上传 `target/nginxWebUI-*.jar` 作为构建产物
- 新增 Docker 镜像构建工作流
  - 下载 JAR 构建产物
  - 使用项目 Dockerfile 构建镜像
  - 支持手动触发构建
- 将 Docker 镜像中的 nginx 升级到 `1.30.1-r0`
- 将可兼容的 `nginx-mod-*` 动态模块同步固定到 `1.30.1-r0`
- 移除 `nginx-mod-http-upstream-jdomain`
  - Alpine edge 当前没有提供该模块的 `1.30.1-r0` 版本
  - 若混用旧版本动态模块，可能导致 nginx 启动时报模块 ABI / 版本不兼容错误
- 其余运行时依赖保持不变

## 兼容性说明

`nginx-mod-http-upstream-jdomain` 是一个第三方 nginx 可选模块，主要用于 upstream 域名动态解析。它并不是 nginxWebUI 本体启动所必需的依赖，也不影响常见的反向代理、SSL 证书、静态站点、负载均衡和 stream 转发等功能。

由于 nginx 动态模块通常需要与 nginx 主程序版本保持一致，因此本 PR 选择移除该模块，而不是混用旧版本模块。

## 测试情况

- JAR 编译工作流执行成功
- Docker 镜像构建工作流执行成功
- Docker 镜像构建成功
- `nginx -v` 显示版本为 `nginx/1.30.1`
- 容器可正常启动